### PR TITLE
feat: Supabase heartbeat & service health system

### DIFF
--- a/apps/web/__tests__/api/heartbeat-status.api.test.ts
+++ b/apps/web/__tests__/api/heartbeat-status.api.test.ts
@@ -1,0 +1,48 @@
+/**
+ * API route tests for heartbeat and status endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as heartbeatGet } from '../../app/api/internal/heartbeat/route'
+
+describe('/api/internal/heartbeat', () => {
+  const cronSecret = 'test-cron-secret-minimum-32-chars!!'
+
+  beforeEach(() => {
+    vi.stubEnv('CRON_SECRET', cronSecret)
+    vi.stubEnv('VERCEL_ENV', 'production')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 without bearer token', async () => {
+    const req = new NextRequest('http://localhost/api/internal/heartbeat')
+    const res = await heartbeatGet(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with wrong bearer token', async () => {
+    const req = new NextRequest('http://localhost/api/internal/heartbeat', {
+      headers: { Authorization: 'Bearer wrong-token' },
+    })
+    const res = await heartbeatGet(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('skips writes outside production', async () => {
+    vi.stubEnv('VERCEL_ENV', 'preview')
+    const req = new NextRequest('http://localhost/api/internal/heartbeat', {
+      headers: { Authorization: `Bearer ${cronSecret}` },
+    })
+    const res = await heartbeatGet(req)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.skipped).toBe(true)
+    expect(body.reason).toBe('non-production')
+  })
+})

--- a/apps/web/__tests__/integration/heartbeat-service-health.integration.test.ts
+++ b/apps/web/__tests__/integration/heartbeat-service-health.integration.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Heartbeat service health integration tests (real PostgreSQL when configured).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import { recordHeartbeat, getLatestHeartbeat } from '@/lib/heartbeat/repository'
+import { evaluateHealthFromLastSeen } from '@/lib/heartbeat/evaluate-health'
+
+const hasDb =
+  !!process.env.DATABASE_URL ||
+  (!!process.env.NEXT_PUBLIC_SUPABASE_URL && !!process.env.SUPABASE_SERVICE_ROLE_KEY)
+
+describe.skipIf(!hasDb)('heartbeat service health (integration)', () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = 'development'
+  })
+
+  it('records heartbeat and reads it back', async () => {
+    const unique = `test-${Date.now()}`
+    await recordHeartbeat({
+      status: 'pass',
+      latencyMs: 1,
+      environment: 'test',
+      source: 'integration-test',
+      metadata: { unique },
+    })
+
+    const row = await getLatestHeartbeat()
+    expect(row).not.toBeNull()
+    expect(row!.status).toBe('pass')
+    expect((row!.metadata as { unique?: string }).unique).toBe(unique)
+  })
+
+  it('evaluates warn and fail thresholds', () => {
+    const now = new Date()
+    const pass = new Date(now.getTime() - 25 * 60 * 60 * 1000)
+    const warn = new Date(now.getTime() - 30 * 60 * 60 * 1000)
+    const fail = new Date(now.getTime() - 50 * 60 * 60 * 1000)
+    expect(evaluateHealthFromLastSeen(pass)).toBe('pass')
+    expect(evaluateHealthFromLastSeen(warn)).toBe('warn')
+    expect(evaluateHealthFromLastSeen(fail)).toBe('fail')
+  })
+})

--- a/apps/web/app/api/internal/heartbeat/route.ts
+++ b/apps/web/app/api/internal/heartbeat/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { sql } from 'drizzle-orm'
+import { db } from '@/lib/db/connection'
+import { verifyCronAuth } from '@/lib/heartbeat/verify-cron-auth'
+import { recordHeartbeat } from '@/lib/heartbeat/repository'
+import { evaluateHealthFromLastSeen } from '@/lib/heartbeat/evaluate-health'
+import { HEARTBEAT_SERVICE_NAME, HEARTBEAT_SOURCE } from '@/lib/heartbeat/constants'
+
+export async function GET(request: NextRequest) {
+  if (!verifyCronAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (process.env.VERCEL_ENV !== 'production') {
+    return NextResponse.json({
+      skipped: true,
+      reason: 'non-production',
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    })
+  }
+
+  const started = Date.now()
+  try {
+    await db.execute(sql`SELECT 1`)
+    const latencyMs = Date.now() - started
+    const now = new Date()
+    const status = evaluateHealthFromLastSeen(now)
+    const environment = process.env.VERCEL_ENV ?? 'production'
+    const deploymentId = process.env.VERCEL_DEPLOYMENT_ID
+
+    await recordHeartbeat({
+      status,
+      latencyMs,
+      environment,
+      deploymentId,
+      source: HEARTBEAT_SOURCE,
+      metadata: { trigger: 'cron' },
+    })
+
+    return NextResponse.json({
+      service: HEARTBEAT_SERVICE_NAME,
+      status,
+      lastSeenAt: now.toISOString(),
+      latencyMs,
+      environment,
+      deploymentId,
+      source: HEARTBEAT_SOURCE,
+    })
+  } catch (error) {
+    console.error('[Heartbeat] failed', error)
+    return NextResponse.json(
+      { error: 'Heartbeat failed', service: HEARTBEAT_SERVICE_NAME },
+      { status: 503 },
+    )
+  }
+}

--- a/apps/web/app/api/status/route.ts
+++ b/apps/web/app/api/status/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { getLatestHeartbeat } from '@/lib/heartbeat/repository'
+import {
+  evaluateHealthFromLastSeen,
+  ageHoursFromLastSeen,
+} from '@/lib/heartbeat/evaluate-health'
+
+export async function GET() {
+  const checkedAt = new Date().toISOString()
+  const row = await getLatestHeartbeat()
+
+  if (!row) {
+    return NextResponse.json({
+      overall: 'fail',
+      checkedAt,
+      services: [],
+    })
+  }
+
+  const lastSeenAt = new Date(row.lastSeenAt)
+  const status = evaluateHealthFromLastSeen(lastSeenAt)
+
+  return NextResponse.json({
+    overall: status,
+    checkedAt,
+    services: [
+      {
+        serviceName: row.serviceName,
+        status,
+        lastSeenAt: lastSeenAt.toISOString(),
+        ageHours: Math.round(ageHoursFromLastSeen(lastSeenAt) * 10) / 10,
+        latencyMs: row.latencyMs,
+        environment: row.environment,
+        source: row.source,
+      },
+    ],
+  })
+}

--- a/apps/web/app/api/status/route.ts
+++ b/apps/web/app/api/status/route.ts
@@ -7,7 +7,19 @@ import {
 
 export async function GET() {
   const checkedAt = new Date().toISOString()
-  const row = await getLatestHeartbeat()
+
+  let row
+  try {
+    row = await getLatestHeartbeat()
+  } catch (error) {
+    console.error('[Status] failed to read heartbeat', error)
+    return NextResponse.json({
+      overall: 'fail',
+      checkedAt,
+      services: [],
+      error: 'Unable to read heartbeat status',
+    })
+  }
 
   if (!row) {
     return NextResponse.json({

--- a/apps/web/env.config.json
+++ b/apps/web/env.config.json
@@ -140,6 +140,15 @@
           "minLength": 100,
           "pattern": "^eyJ[A-Za-z0-9_-]*\\.[A-Za-z0-9_-]*\\.[A-Za-z0-9_-]*$"
         }
+      },
+      {
+        "name": "CRON_SECRET",
+        "description": "Bearer secret for Vercel Cron invocations of internal heartbeat",
+        "type": "string",
+        "sensitive": true,
+        "validation": {
+          "minLength": 32
+        }
       }
     ]
   },

--- a/apps/web/lib/db/migrations/0001_strong_black_cat.sql
+++ b/apps/web/lib/db/migrations/0001_strong_black_cat.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "service_heartbeat_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"service_name" text NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"status" text NOT NULL,
+	"latency_ms" integer,
+	"metadata" jsonb DEFAULT '{}'::jsonb
+);
+--> statement-breakpoint
+CREATE TABLE "service_heartbeats" (
+	"service_name" text PRIMARY KEY NOT NULL,
+	"last_seen_at" timestamp with time zone NOT NULL,
+	"source" text NOT NULL,
+	"environment" text NOT NULL,
+	"status" text NOT NULL,
+	"latency_ms" integer,
+	"deployment_id" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX "service_heartbeat_events_service_occurred_idx" ON "service_heartbeat_events" USING btree ("service_name","occurred_at");

--- a/apps/web/lib/db/migrations/meta/0001_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,4374 @@
+{
+  "id": "808bde55-345a-4af8-8bf9-dc0189b14553",
+  "prevId": "4739f89c-02e0-4030-a508-4a67efb5c696",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_organization_id_idx": {
+          "name": "audit_logs_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_resource_type_idx": {
+          "name": "audit_logs_resource_type_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_resource_id_idx": {
+          "name": "audit_logs_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_severity_idx": {
+          "name": "audit_logs_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_user_action_idx": {
+          "name": "audit_logs_user_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_org_action_idx": {
+          "name": "audit_logs_org_action_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_resource_idx": {
+          "name": "audit_logs_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_time_range_idx": {
+          "name": "audit_logs_time_range_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_organization_id_organizations_id_fk": {
+          "name": "audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'error'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_method": {
+          "name": "http_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "error_logs_error_type_idx": {
+          "name": "error_logs_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_severity_idx": {
+          "name": "error_logs_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_user_id_idx": {
+          "name": "error_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_organization_id_idx": {
+          "name": "error_logs_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_endpoint_idx": {
+          "name": "error_logs_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_resolved_idx": {
+          "name": "error_logs_resolved_idx",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_created_at_idx": {
+          "name": "error_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_type_resolved_idx": {
+          "name": "error_logs_type_resolved_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_logs_severity_resolved_idx": {
+          "name": "error_logs_severity_resolved_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "error_logs_user_id_users_id_fk": {
+          "name": "error_logs_user_id_users_id_fk",
+          "tableFrom": "error_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "error_logs_organization_id_organizations_id_fk": {
+          "name": "error_logs_organization_id_organizations_id_fk",
+          "tableFrom": "error_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "error_logs_resolved_by_users_id_fk": {
+          "name": "error_logs_resolved_by_users_id_fk",
+          "tableFrom": "error_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_analytics": {
+      "name": "onboarding_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "path_id": {
+          "name": "path_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "performance_metrics": {
+          "name": "performance_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_analytics_organization_id_idx": {
+          "name": "onboarding_analytics_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_session_id_idx": {
+          "name": "onboarding_analytics_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_user_id_idx": {
+          "name": "onboarding_analytics_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_event_type_idx": {
+          "name": "onboarding_analytics_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_path_id_idx": {
+          "name": "onboarding_analytics_path_id_idx",
+          "columns": [
+            {
+              "expression": "path_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_step_id_idx": {
+          "name": "onboarding_analytics_step_id_idx",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_timestamp_idx": {
+          "name": "onboarding_analytics_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_org_event_idx": {
+          "name": "onboarding_analytics_org_event_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_session_event_idx": {
+          "name": "onboarding_analytics_session_event_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_path_event_idx": {
+          "name": "onboarding_analytics_path_event_idx",
+          "columns": [
+            {
+              "expression": "path_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_analytics_time_range_idx": {
+          "name": "onboarding_analytics_time_range_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_analytics_organization_id_organizations_id_fk": {
+          "name": "onboarding_analytics_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_analytics",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_analytics_session_id_onboarding_sessions_id_fk": {
+          "name": "onboarding_analytics_session_id_onboarding_sessions_id_fk",
+          "tableFrom": "onboarding_analytics",
+          "tableTo": "onboarding_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_analytics_user_id_users_id_fk": {
+          "name": "onboarding_analytics_user_id_users_id_fk",
+          "tableFrom": "onboarding_analytics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_analytics_path_id_onboarding_paths_id_fk": {
+          "name": "onboarding_analytics_path_id_onboarding_paths_id_fk",
+          "tableFrom": "onboarding_analytics",
+          "tableTo": "onboarding_paths",
+          "columnsFrom": [
+            "path_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_analytics_step_id_onboarding_steps_id_fk": {
+          "name": "onboarding_analytics_step_id_onboarding_steps_id_fk",
+          "tableFrom": "onboarding_analytics",
+          "tableTo": "onboarding_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_metrics": {
+      "name": "system_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "metric_type": {
+          "name": "metric_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aggregation_period": {
+          "name": "aggregation_period",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_metrics_metric_type_idx": {
+          "name": "system_metrics_metric_type_idx",
+          "columns": [
+            {
+              "expression": "metric_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_metric_name_idx": {
+          "name": "system_metrics_metric_name_idx",
+          "columns": [
+            {
+              "expression": "metric_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_organization_id_idx": {
+          "name": "system_metrics_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_timestamp_idx": {
+          "name": "system_metrics_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_aggregation_period_idx": {
+          "name": "system_metrics_aggregation_period_idx",
+          "columns": [
+            {
+              "expression": "aggregation_period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_type_name_idx": {
+          "name": "system_metrics_type_name_idx",
+          "columns": [
+            {
+              "expression": "metric_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_org_metric_idx": {
+          "name": "system_metrics_org_metric_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_metrics_time_range_idx": {
+          "name": "system_metrics_time_range_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_metrics_organization_id_organizations_id_fk": {
+          "name": "system_metrics_organization_id_organizations_id_fk",
+          "tableFrom": "system_metrics",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "system_metrics_user_id_users_id_fk": {
+          "name": "system_metrics_user_id_users_id_fk",
+          "tableFrom": "system_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_content": {
+      "name": "onboarding_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_data": {
+          "name": "content_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "interactive_config": {
+          "name": "interactive_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_content_content_type_idx": {
+          "name": "onboarding_content_content_type_idx",
+          "columns": [
+            {
+              "expression": "content_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_content_organization_id_idx": {
+          "name": "onboarding_content_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_content_created_by_idx": {
+          "name": "onboarding_content_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_content_is_active_idx": {
+          "name": "onboarding_content_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_content_title_idx": {
+          "name": "onboarding_content_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_content_organization_id_organizations_id_fk": {
+          "name": "onboarding_content_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_content_created_by_users_id_fk": {
+          "name": "onboarding_content_created_by_users_id_fk",
+          "tableFrom": "onboarding_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_paths": {
+      "name": "onboarding_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_role": {
+          "name": "target_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_duration": {
+          "name": "estimated_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "learning_objectives": {
+          "name": "learning_objectives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "success_criteria": {
+          "name": "success_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_paths_target_role_idx": {
+          "name": "onboarding_paths_target_role_idx",
+          "columns": [
+            {
+              "expression": "target_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_paths_subscription_tier_idx": {
+          "name": "onboarding_paths_subscription_tier_idx",
+          "columns": [
+            {
+              "expression": "subscription_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_paths_is_active_idx": {
+          "name": "onboarding_paths_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_paths_name_idx": {
+          "name": "onboarding_paths_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_sessions": {
+      "name": "onboarding_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_id": {
+          "name": "path_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_step_id": {
+          "name": "current_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step_index": {
+          "name": "current_step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_percentage": {
+          "name": "progress_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time_spent": {
+          "name": "time_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_metadata": {
+          "name": "session_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_sessions_user_id_idx": {
+          "name": "onboarding_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_sessions_organization_id_idx": {
+          "name": "onboarding_sessions_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_sessions_path_id_idx": {
+          "name": "onboarding_sessions_path_id_idx",
+          "columns": [
+            {
+              "expression": "path_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_sessions_status_idx": {
+          "name": "onboarding_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_sessions_session_type_idx": {
+          "name": "onboarding_sessions_session_type_idx",
+          "columns": [
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_sessions_last_active_at_idx": {
+          "name": "onboarding_sessions_last_active_at_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_sessions_user_id_users_id_fk": {
+          "name": "onboarding_sessions_user_id_users_id_fk",
+          "tableFrom": "onboarding_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_sessions_organization_id_organizations_id_fk": {
+          "name": "onboarding_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_sessions_path_id_onboarding_paths_id_fk": {
+          "name": "onboarding_sessions_path_id_onboarding_paths_id_fk",
+          "tableFrom": "onboarding_sessions",
+          "tableTo": "onboarding_paths",
+          "columnsFrom": [
+            "path_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "onboarding_sessions_current_step_id_onboarding_steps_id_fk": {
+          "name": "onboarding_sessions_current_step_id_onboarding_steps_id_fk",
+          "tableFrom": "onboarding_sessions",
+          "tableTo": "onboarding_steps",
+          "columnsFrom": [
+            "current_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_steps": {
+      "name": "onboarding_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path_id": {
+          "name": "path_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_time": {
+          "name": "estimated_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "interactive_elements": {
+          "name": "interactive_elements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "success_criteria": {
+          "name": "success_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "validation_rules": {
+          "name": "validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_steps_path_id_idx": {
+          "name": "onboarding_steps_path_id_idx",
+          "columns": [
+            {
+              "expression": "path_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_steps_step_type_idx": {
+          "name": "onboarding_steps_step_type_idx",
+          "columns": [
+            {
+              "expression": "step_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_steps_step_order_idx": {
+          "name": "onboarding_steps_step_order_idx",
+          "columns": [
+            {
+              "expression": "step_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_steps_is_required_idx": {
+          "name": "onboarding_steps_is_required_idx",
+          "columns": [
+            {
+              "expression": "is_required",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_steps_path_order_idx": {
+          "name": "onboarding_steps_path_order_idx",
+          "columns": [
+            {
+              "expression": "path_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_steps_path_id_onboarding_paths_id_fk": {
+          "name": "onboarding_steps_path_id_onboarding_paths_id_fk",
+          "tableFrom": "onboarding_steps",
+          "tableTo": "onboarding_paths",
+          "columnsFrom": [
+            "path_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_onboarding_configs": {
+      "name": "organization_onboarding_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_assets": {
+          "name": "branding_assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "custom_content": {
+          "name": "custom_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "role_configurations": {
+          "name": "role_configurations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "mandatory_modules": {
+          "name": "mandatory_modules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "completion_requirements": {
+          "name": "completion_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "integration_settings": {
+          "name": "integration_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_onboarding_configs_organization_id_idx": {
+          "name": "org_onboarding_configs_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_onboarding_configs_is_active_idx": {
+          "name": "org_onboarding_configs_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_onboarding_configs_organization_id_organizations_id_fk": {
+          "name": "organization_onboarding_configs_organization_id_organizations_id_fk",
+          "tableFrom": "organization_onboarding_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_onboarding_configs_organization_id_unique": {
+          "name": "organization_onboarding_configs_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_spent": {
+          "name": "time_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_actions": {
+          "name": "user_actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "step_result": {
+          "name": "step_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "achievements": {
+          "name": "achievements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_session_id_idx": {
+          "name": "user_progress_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_step_id_idx": {
+          "name": "user_progress_step_id_idx",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_user_id_idx": {
+          "name": "user_progress_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_status_idx": {
+          "name": "user_progress_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_session_step_idx": {
+          "name": "user_progress_session_step_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_user_step_idx": {
+          "name": "user_progress_user_step_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_session_id_onboarding_sessions_id_fk": {
+          "name": "user_progress_session_id_onboarding_sessions_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "onboarding_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_step_id_onboarding_steps_id_fk": {
+          "name": "user_progress_step_id_onboarding_steps_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "onboarding_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_user_id_users_id_fk": {
+          "name": "user_progress_user_id_users_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_id_idx": {
+          "name": "org_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_organization_id_idx": {
+          "name": "org_memberships_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_role_id_idx": {
+          "name": "org_memberships_role_id_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_status_idx": {
+          "name": "org_memberships_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_role_id_roles_id_fk": {
+          "name": "organization_memberships_role_id_roles_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_name_idx": {
+          "name": "organizations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_created_at_idx": {
+          "name": "organizations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_name_idx": {
+          "name": "permissions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_resource_idx": {
+          "name": "permissions_resource_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_action_idx": {
+          "name": "permissions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_resource_action_idx": {
+          "name": "permissions_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system_role": {
+          "name": "is_system_role",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roles_organization_id_idx": {
+          "name": "roles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roles_name_idx": {
+          "name": "roles_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roles_is_system_role_idx": {
+          "name": "roles_is_system_role_idx",
+          "columns": [
+            {
+              "expression": "is_system_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roles_org_name_idx": {
+          "name": "roles_org_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_organization_id_organizations_id_fk": {
+          "name": "roles_organization_id_organizations_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_organization_id_idx": {
+          "name": "invitations_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_token_idx": {
+          "name": "invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invited_by_idx": {
+          "name": "invitations_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_expires_at_idx": {
+          "name": "invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_org_email_idx": {
+          "name": "invitations_org_email_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_expires_idx": {
+          "name": "invitations_status_expires_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_role_id_roles_id_fk": {
+          "name": "invitations_role_id_roles_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_milestones": {
+      "name": "onboarding_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_type": {
+          "name": "milestone_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reward_data": {
+          "name": "reward_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_milestones_milestone_type_idx": {
+          "name": "onboarding_milestones_milestone_type_idx",
+          "columns": [
+            {
+              "expression": "milestone_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_milestones_organization_id_idx": {
+          "name": "onboarding_milestones_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_milestones_is_active_idx": {
+          "name": "onboarding_milestones_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_milestones_name_idx": {
+          "name": "onboarding_milestones_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_milestones_organization_id_organizations_id_fk": {
+          "name": "onboarding_milestones_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_milestones",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_message": {
+          "name": "custom_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_path_override": {
+          "name": "onboarding_path_override",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitation_token": {
+          "name": "invitation_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_session_id": {
+          "name": "onboarding_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_organization_id_idx": {
+          "name": "team_invitations_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_email_idx": {
+          "name": "team_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_invitation_token_idx": {
+          "name": "team_invitations_invitation_token_idx",
+          "columns": [
+            {
+              "expression": "invitation_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_status_idx": {
+          "name": "team_invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_invited_by_idx": {
+          "name": "team_invitations_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_expires_at_idx": {
+          "name": "team_invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_onboarding_path_override_idx": {
+          "name": "team_invitations_onboarding_path_override_idx",
+          "columns": [
+            {
+              "expression": "onboarding_path_override",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_org_email_idx": {
+          "name": "team_invitations_org_email_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_status_expires_idx": {
+          "name": "team_invitations_status_expires_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_organization_id_organizations_id_fk": {
+          "name": "team_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_users_id_fk": {
+          "name": "team_invitations_invited_by_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_onboarding_path_override_onboarding_paths_id_fk": {
+          "name": "team_invitations_onboarding_path_override_onboarding_paths_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "onboarding_paths",
+          "columnsFrom": [
+            "onboarding_path_override"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_onboarding_session_id_onboarding_sessions_id_fk": {
+          "name": "team_invitations_onboarding_session_id_onboarding_sessions_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "onboarding_sessions",
+          "columnsFrom": [
+            "onboarding_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_invitations_invitation_token_unique": {
+          "name": "team_invitations_invitation_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "achievement_data": {
+          "name": "achievement_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_achievements_user_id_idx": {
+          "name": "user_achievements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_session_id_idx": {
+          "name": "user_achievements_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_milestone_id_idx": {
+          "name": "user_achievements_milestone_id_idx",
+          "columns": [
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_earned_at_idx": {
+          "name": "user_achievements_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_milestone_idx": {
+          "name": "user_achievements_user_milestone_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_session_milestone_idx": {
+          "name": "user_achievements_session_milestone_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_achievements_session_id_onboarding_sessions_id_fk": {
+          "name": "user_achievements_session_id_onboarding_sessions_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "onboarding_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_achievements_milestone_id_onboarding_milestones_id_fk": {
+          "name": "user_achievements_milestone_id_onboarding_milestones_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "onboarding_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_heartbeat_events": {
+      "name": "service_heartbeat_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "service_heartbeat_events_service_occurred_idx": {
+          "name": "service_heartbeat_events_service_occurred_idx",
+          "columns": [
+            {
+              "expression": "service_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_heartbeats": {
+      "name": "service_heartbeats",
+      "schema": "",
+      "columns": {
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759606811390,
       "tag": "0000_typical_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779149876497,
+      "tag": "0001_strong_black_cat",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/index.ts
+++ b/apps/web/lib/db/schema/index.ts
@@ -18,6 +18,7 @@ export * from './roles'
 export * from './content'
 export * from './invitations'
 export * from './audit'
+export * from './service-heartbeats'
 
 // Re-export all table schemas for Drizzle ORM
 import { users } from './users'
@@ -43,6 +44,7 @@ import {
   systemMetrics, 
   errorLogs 
 } from './audit'
+import { serviceHeartbeats, serviceHeartbeatEvents } from './service-heartbeats'
 
 // Import relations
 import { allRelations } from './relations'
@@ -75,6 +77,8 @@ export const schema = {
   onboardingAnalytics,
   systemMetrics,
   errorLogs,
+  serviceHeartbeats,
+  serviceHeartbeatEvents,
   
   // Relations
   ...allRelations
@@ -103,7 +107,9 @@ export const TABLE_NAMES = {
   AUDIT_LOGS: 'audit_logs',
   ONBOARDING_ANALYTICS: 'onboarding_analytics',
   SYSTEM_METRICS: 'system_metrics',
-  ERROR_LOGS: 'error_logs'
+  ERROR_LOGS: 'error_logs',
+  SERVICE_HEARTBEATS: 'service_heartbeats',
+  SERVICE_HEARTBEAT_EVENTS: 'service_heartbeat_events'
 } as const
 
 export type TableName = keyof typeof TABLE_NAMES

--- a/apps/web/lib/db/schema/service-heartbeats.ts
+++ b/apps/web/lib/db/schema/service-heartbeats.ts
@@ -1,0 +1,41 @@
+/**
+ * Service heartbeat schema for platform liveness tracking.
+ */
+
+import { pgTable, text, timestamp, integer, jsonb, uuid, index } from 'drizzle-orm/pg-core'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+
+export const serviceHeartbeats = pgTable('service_heartbeats', {
+  serviceName: text('service_name').primaryKey(),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull(),
+  source: text('source').notNull(),
+  environment: text('environment').notNull(),
+  status: text('status').notNull(),
+  latencyMs: integer('latency_ms'),
+  deploymentId: text('deployment_id'),
+  metadata: jsonb('metadata').notNull().default({}),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+})
+
+export const serviceHeartbeatEvents = pgTable(
+  'service_heartbeat_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    serviceName: text('service_name').notNull(),
+    occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
+    status: text('status').notNull(),
+    latencyMs: integer('latency_ms'),
+    metadata: jsonb('metadata').default({}),
+  },
+  (table) => ({
+    serviceOccurredIdx: index('service_heartbeat_events_service_occurred_idx').on(
+      table.serviceName,
+      table.occurredAt,
+    ),
+  }),
+)
+
+export type ServiceHeartbeat = InferSelectModel<typeof serviceHeartbeats>
+export type NewServiceHeartbeat = InferInsertModel<typeof serviceHeartbeats>
+export type ServiceHeartbeatEvent = InferSelectModel<typeof serviceHeartbeatEvents>
+export type NewServiceHeartbeatEvent = InferInsertModel<typeof serviceHeartbeatEvents>

--- a/apps/web/lib/heartbeat/constants.ts
+++ b/apps/web/lib/heartbeat/constants.ts
@@ -1,0 +1,5 @@
+export const HEARTBEAT_SERVICE_NAME = 'supabase' as const
+export const HEARTBEAT_SOURCE = 'vercel-cron' as const
+
+export const HEALTH_PASS_MAX_HOURS = 26
+export const HEALTH_WARN_MAX_HOURS = 48

--- a/apps/web/lib/heartbeat/evaluate-health.ts
+++ b/apps/web/lib/heartbeat/evaluate-health.ts
@@ -1,0 +1,14 @@
+import { HEALTH_PASS_MAX_HOURS, HEALTH_WARN_MAX_HOURS } from './constants'
+
+export type HealthStatus = 'pass' | 'warn' | 'fail'
+
+export function evaluateHealthFromLastSeen(lastSeenAt: Date, now = new Date()): HealthStatus {
+  const ageHours = (now.getTime() - lastSeenAt.getTime()) / (1000 * 60 * 60)
+  if (ageHours < HEALTH_PASS_MAX_HOURS) return 'pass'
+  if (ageHours < HEALTH_WARN_MAX_HOURS) return 'warn'
+  return 'fail'
+}
+
+export function ageHoursFromLastSeen(lastSeenAt: Date, now = new Date()): number {
+  return (now.getTime() - lastSeenAt.getTime()) / (1000 * 60 * 60)
+}

--- a/apps/web/lib/heartbeat/repository.ts
+++ b/apps/web/lib/heartbeat/repository.ts
@@ -1,0 +1,63 @@
+import { db } from '@/lib/db/connection'
+import { serviceHeartbeats, serviceHeartbeatEvents } from '@/lib/db/schema/service-heartbeats'
+import { eq } from 'drizzle-orm'
+import { HEARTBEAT_SERVICE_NAME } from './constants'
+import type { HealthStatus } from './evaluate-health'
+
+export type RecordHeartbeatInput = {
+  status: HealthStatus
+  latencyMs: number
+  environment: string
+  deploymentId?: string
+  source: string
+  metadata?: Record<string, unknown>
+}
+
+export async function recordHeartbeat(input: RecordHeartbeatInput) {
+  const now = new Date()
+  const metadata = input.metadata ?? {}
+
+  await db
+    .insert(serviceHeartbeats)
+    .values({
+      serviceName: HEARTBEAT_SERVICE_NAME,
+      lastSeenAt: now,
+      source: input.source,
+      environment: input.environment,
+      status: input.status,
+      latencyMs: input.latencyMs,
+      deploymentId: input.deploymentId,
+      metadata,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: serviceHeartbeats.serviceName,
+      set: {
+        lastSeenAt: now,
+        source: input.source,
+        environment: input.environment,
+        status: input.status,
+        latencyMs: input.latencyMs,
+        deploymentId: input.deploymentId,
+        metadata,
+        updatedAt: now,
+      },
+    })
+
+  await db.insert(serviceHeartbeatEvents).values({
+    serviceName: HEARTBEAT_SERVICE_NAME,
+    occurredAt: now,
+    status: input.status,
+    latencyMs: input.latencyMs,
+    metadata,
+  })
+}
+
+export async function getLatestHeartbeat(serviceName = HEARTBEAT_SERVICE_NAME) {
+  const [row] = await db
+    .select()
+    .from(serviceHeartbeats)
+    .where(eq(serviceHeartbeats.serviceName, serviceName))
+    .limit(1)
+  return row ?? null
+}

--- a/apps/web/lib/heartbeat/verify-cron-auth.ts
+++ b/apps/web/lib/heartbeat/verify-cron-auth.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server'
+
+export function verifyCronAuth(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  const auth = request.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return false
+  const token = auth.slice('Bearer '.length).trim()
+  return token.length > 0 && token === secret
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -23,6 +23,8 @@ const routeProtection = new Map<RegExp, ProtectionLevel>([
   [/^\/verify-email/, ProtectionLevel.PUBLIC],
   [/^\/reset-password/, ProtectionLevel.PUBLIC],
   [/^\/api\/health/, ProtectionLevel.PUBLIC],
+  [/^\/api\/status/, ProtectionLevel.PUBLIC],
+  [/^\/api\/internal\/heartbeat/, ProtectionLevel.PUBLIC],
   [/^\/api\/webhooks/, ProtectionLevel.PUBLIC],
   [/^\/api\/example-error-handling/, ProtectionLevel.PUBLIC],
   
@@ -88,6 +90,8 @@ const isPublicRoute = createRouteMatcher([
   '/verify-email(.*)',
   '/reset-password(.*)',
   '/api/health(.*)',
+  '/api/status',
+  '/api/internal/heartbeat',
   '/api/webhooks(.*)',
   '/api/example-error-handling(.*)'
 ])

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -60,7 +60,12 @@
       "permanent": true
     }
   ],
-  "crons": [],
+  "crons": [
+    {
+      "path": "/api/internal/heartbeat",
+      "schedule": "0 5 * * *"
+    }
+  ],
   "regions": ["iad1"],
   "cleanUrls": true,
   "trailingSlash": false

--- a/docs/superpowers/plans/2026-05-19-supabase-heartbeat-service-health.md
+++ b/docs/superpowers/plans/2026-05-19-supabase-heartbeat-service-health.md
@@ -1,0 +1,801 @@
+# Supabase Heartbeat & Service Health System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a production-only Vercel Cron heartbeat that writes to Supabase Postgres (via Drizzle), prevents Supabase inactivity pausing, and exposes `/api/status` for computed platform health.
+
+**Architecture:** Add `service_heartbeats` (canonical upsert per service) and `service_heartbeat_events` (append-only audit trail). A secured internal route (`GET /api/internal/heartbeat`) runs daily in production only, measures DB round-trip latency, and persists results. A public status route (`GET /api/status`) reads the canonical row and maps `last_seen_at` age to `pass` / `warn` / `fail`. Database access uses the existing Drizzle `db` singleton (service-role `DATABASE_URL`), not the browser Supabase client.
+
+**Tech Stack:** Next.js App Router, Drizzle ORM, PostgreSQL (Supabase), Vercel Cron, Vitest integration tests with real Postgres.
+
+---
+
+## Context & Codebase Fit
+
+| Area | Current state | Plan action |
+|------|---------------|-------------|
+| DB access | `apps/web/lib/db/connection.ts` → Drizzle on Supabase Postgres | Reuse `db` for writes/reads |
+| Migrations | Drizzle (`apps/web/lib/db/migrations/`) + Supabase SQL (`supabase/migrations/`) | Both must be updated |
+| Health today | `/api/health` = config manager liveness | Keep separate; add `/api/status` |
+| Cron | `apps/web/vercel.json` has `"crons": []` | Add daily heartbeat cron |
+| Auth middleware | Clerk protects most `/api/*` | Mark heartbeat + status routes public; cron uses `CRON_SECRET` |
+| Env config | `apps/web/env.config.json` | Add `CRON_SECRET` |
+
+**Canonical service name:** `supabase` (constant `HEARTBEAT_SERVICE_NAME`).
+
+**Health thresholds (hours since `last_seen_at`):**
+
+| Status | Condition |
+|--------|-----------|
+| `pass` | `< 26` |
+| `warn` | `>= 26` and `< 48` |
+| `fail` | `>= 48` |
+
+Cron schedule `0 5 * * *` ⇒ max gap ~24h in normal operation; thresholds give buffer before `fail`.
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/lib/db/schema/service-heartbeats.ts` | Drizzle table definitions + types |
+| `apps/web/lib/db/schema/index.ts` | Export new schema |
+| `apps/web/lib/db/schema/relations.ts` | Optional relations (events → none FK required) |
+| `supabase/migrations/20260519000000_service_heartbeats.sql` | SQL tables + RLS |
+| `apps/web/lib/heartbeat/constants.ts` | Service name, source, thresholds |
+| `apps/web/lib/heartbeat/evaluate-health.ts` | `pass` / `warn` / `fail` from timestamp |
+| `apps/web/lib/heartbeat/verify-cron-auth.ts` | Bearer `CRON_SECRET` validation |
+| `apps/web/lib/heartbeat/repository.ts` | Upsert + event insert + read latest |
+| `apps/web/lib/heartbeat/types.ts` | Shared TS types for API responses |
+| `apps/web/app/api/internal/heartbeat/route.ts` | Cron target (GET) |
+| `apps/web/app/api/status/route.ts` | Public health read (GET) |
+| `apps/web/vercel.json` | Cron entry |
+| `apps/web/middleware.ts` | Public route matchers |
+| `apps/web/env.config.json` | `CRON_SECRET` definition |
+| `apps/web/__tests__/integration/heartbeat-service-health.integration.test.ts` | Real DB integration tests |
+| `apps/web/__tests__/api/heartbeat-status.api.test.ts` | Route auth + response shape (mock repo where needed) |
+| `docs/vercel-deployment.md` | Post-verify: document env + cron (after implementation proven) |
+
+---
+
+## API Contracts
+
+### `GET /api/internal/heartbeat`
+
+**Auth:** `Authorization: Bearer <CRON_SECRET>` → else `401`.
+
+**Production guard:** If `process.env.VERCEL_ENV !== 'production'`, return `200` with `{ skipped: true, reason: 'non-production' }` and **no DB writes**.
+
+**Success `200`:**
+
+```json
+{
+  "service": "supabase",
+  "status": "pass",
+  "lastSeenAt": "2026-05-19T05:00:01.123Z",
+  "latencyMs": 42,
+  "environment": "production",
+  "deploymentId": "dpl_xxx",
+  "source": "vercel-cron"
+}
+```
+
+**Failure `503`:** DB error with safe message (no secrets).
+
+### `GET /api/status`
+
+**Auth:** Public (no Clerk).
+
+**Success `200`:**
+
+```json
+{
+  "overall": "pass",
+  "checkedAt": "2026-05-19T12:00:00.000Z",
+  "services": [
+    {
+      "serviceName": "supabase",
+      "status": "pass",
+      "lastSeenAt": "2026-05-19T05:00:01.123Z",
+      "ageHours": 7.0,
+      "latencyMs": 42,
+      "environment": "production",
+      "source": "vercel-cron"
+    }
+  ]
+}
+```
+
+**No heartbeat row yet:** `overall: "fail"`, `services: []` or explicit `unknown` entry.
+
+---
+
+## Security & RLS
+
+- Enable RLS on both tables in Supabase migration.
+- **No** `SELECT`/`INSERT` policies for `anon` or `authenticated` roles (server uses `DATABASE_URL` / service role, bypasses RLS).
+- Do not expose these tables via PostgREST to the anon key.
+- `CRON_SECRET`: min 32 chars, stored only in Vercel Production env (and Phase production app).
+
+---
+
+## Task 1: Drizzle Schema
+
+**Files:**
+- Create: `apps/web/lib/db/schema/service-heartbeats.ts`
+- Modify: `apps/web/lib/db/schema/index.ts`
+- Modify: `apps/web/lib/db/schema/relations.ts` (if exporting schema object)
+
+- [ ] **Step 1: Add Drizzle schema**
+
+```typescript
+// apps/web/lib/db/schema/service-heartbeats.ts
+import { pgTable, text, timestamp, integer, jsonb, uuid, index } from 'drizzle-orm/pg-core'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+
+export const serviceHeartbeats = pgTable('service_heartbeats', {
+  serviceName: text('service_name').primaryKey(),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull(),
+  source: text('source').notNull(),
+  environment: text('environment').notNull(),
+  status: text('status').notNull(),
+  latencyMs: integer('latency_ms'),
+  deploymentId: text('deployment_id'),
+  metadata: jsonb('metadata').notNull().default({}),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+})
+
+export const serviceHeartbeatEvents = pgTable('service_heartbeat_events', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  serviceName: text('service_name').notNull(),
+  occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
+  status: text('status').notNull(),
+  latencyMs: integer('latency_ms'),
+  metadata: jsonb('metadata').default({}),
+}, (table) => ({
+  serviceOccurredIdx: index('service_heartbeat_events_service_occurred_idx').on(
+    table.serviceName,
+    table.occurredAt,
+  ),
+}))
+
+export type ServiceHeartbeat = InferSelectModel<typeof serviceHeartbeats>
+export type NewServiceHeartbeat = InferInsertModel<typeof serviceHeartbeats>
+export type ServiceHeartbeatEvent = InferSelectModel<typeof serviceHeartbeatEvents>
+export type NewServiceHeartbeatEvent = InferInsertModel<typeof serviceHeartbeatEvents>
+```
+
+- [ ] **Step 2: Export from `index.ts`**
+
+Add:
+
+```typescript
+export * from './service-heartbeats'
+```
+
+And register tables in the `schema` const + `TABLE_NAMES`.
+
+- [ ] **Step 3: Generate Drizzle migration**
+
+Run:
+
+```bash
+cd /workspace && pnpm db:generate
+```
+
+Expected: new SQL file under `apps/web/lib/db/migrations/` creating both tables.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/db/schema/service-heartbeats.ts apps/web/lib/db/schema/index.ts apps/web/lib/db/migrations/
+git commit -m "feat(db): add service heartbeat schema"
+```
+
+---
+
+## Task 2: Supabase SQL Migration (RLS)
+
+**Files:**
+- Create: `supabase/migrations/20260519000000_service_heartbeats.sql`
+
+- [ ] **Step 1: Write migration SQL**
+
+```sql
+-- Service heartbeat tables for platform liveness (server-side writes only)
+CREATE TABLE IF NOT EXISTS service_heartbeats (
+  service_name text PRIMARY KEY,
+  last_seen_at timestamptz NOT NULL,
+  source text NOT NULL,
+  environment text NOT NULL,
+  status text NOT NULL,
+  latency_ms integer,
+  deployment_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS service_heartbeat_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_name text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  status text NOT NULL,
+  latency_ms integer,
+  metadata jsonb DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS service_heartbeat_events_service_occurred_idx
+  ON service_heartbeat_events (service_name, occurred_at DESC);
+
+ALTER TABLE service_heartbeats ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_heartbeat_events ENABLE ROW LEVEL SECURITY;
+-- Intentionally no policies: only service_role / direct Postgres (Drizzle) may access.
+```
+
+- [ ] **Step 2: Apply locally (if Supabase CLI available)**
+
+```bash
+supabase db push
+# or: pnpm db:migrate (Drizzle path for local dev DB)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260519000000_service_heartbeats.sql
+git commit -m "feat(supabase): service heartbeat tables with RLS enabled"
+```
+
+---
+
+## Task 3: Heartbeat Library
+
+**Files:**
+- Create: `apps/web/lib/heartbeat/constants.ts`
+- Create: `apps/web/lib/heartbeat/evaluate-health.ts`
+- Create: `apps/web/lib/heartbeat/verify-cron-auth.ts`
+- Create: `apps/web/lib/heartbeat/types.ts`
+- Create: `apps/web/lib/heartbeat/repository.ts`
+
+- [ ] **Step 1: Constants**
+
+```typescript
+// apps/web/lib/heartbeat/constants.ts
+export const HEARTBEAT_SERVICE_NAME = 'supabase' as const
+export const HEARTBEAT_SOURCE = 'vercel-cron' as const
+
+export const HEALTH_PASS_MAX_HOURS = 26
+export const HEALTH_WARN_MAX_HOURS = 48
+```
+
+- [ ] **Step 2: Health evaluation**
+
+```typescript
+// apps/web/lib/heartbeat/evaluate-health.ts
+import { HEALTH_PASS_MAX_HOURS, HEALTH_WARN_MAX_HOURS } from './constants'
+
+export type HealthStatus = 'pass' | 'warn' | 'fail'
+
+export function evaluateHealthFromLastSeen(lastSeenAt: Date, now = new Date()): HealthStatus {
+  const ageHours = (now.getTime() - lastSeenAt.getTime()) / (1000 * 60 * 60)
+  if (ageHours < HEALTH_PASS_MAX_HOURS) return 'pass'
+  if (ageHours < HEALTH_WARN_MAX_HOURS) return 'warn'
+  return 'fail'
+}
+
+export function ageHoursFromLastSeen(lastSeenAt: Date, now = new Date()): number {
+  return (now.getTime() - lastSeenAt.getTime()) / (1000 * 60 * 60)
+}
+```
+
+- [ ] **Step 3: Cron auth helper**
+
+```typescript
+// apps/web/lib/heartbeat/verify-cron-auth.ts
+import { NextRequest } from 'next/server'
+
+export function verifyCronAuth(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return false
+  const auth = request.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return false
+  const token = auth.slice('Bearer '.length).trim()
+  return token.length > 0 && token === secret
+}
+```
+
+- [ ] **Step 4: Repository**
+
+```typescript
+// apps/web/lib/heartbeat/repository.ts
+import { db } from '@/lib/db/connection'
+import { serviceHeartbeats, serviceHeartbeatEvents } from '@/lib/db/schema/service-heartbeats'
+import { eq } from 'drizzle-orm'
+import { HEARTBEAT_SERVICE_NAME } from './constants'
+import type { HealthStatus } from './evaluate-health'
+
+export type RecordHeartbeatInput = {
+  status: HealthStatus
+  latencyMs: number
+  environment: string
+  deploymentId?: string
+  source: string
+  metadata?: Record<string, unknown>
+}
+
+export async function recordHeartbeat(input: RecordHeartbeatInput) {
+  const now = new Date()
+  const metadata = input.metadata ?? {}
+
+  await db
+    .insert(serviceHeartbeats)
+    .values({
+      serviceName: HEARTBEAT_SERVICE_NAME,
+      lastSeenAt: now,
+      source: input.source,
+      environment: input.environment,
+      status: input.status,
+      latencyMs: input.latencyMs,
+      deploymentId: input.deploymentId,
+      metadata,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: serviceHeartbeats.serviceName,
+      set: {
+        lastSeenAt: now,
+        source: input.source,
+        environment: input.environment,
+        status: input.status,
+        latencyMs: input.latencyMs,
+        deploymentId: input.deploymentId,
+        metadata,
+        updatedAt: now,
+      },
+    })
+
+  await db.insert(serviceHeartbeatEvents).values({
+    serviceName: HEARTBEAT_SERVICE_NAME,
+    occurredAt: now,
+    status: input.status,
+    latencyMs: input.latencyMs,
+    metadata,
+  })
+}
+
+export async function getLatestHeartbeat(serviceName = HEARTBEAT_SERVICE_NAME) {
+  const [row] = await db
+    .select()
+    .from(serviceHeartbeats)
+    .where(eq(serviceHeartbeats.serviceName, serviceName))
+    .limit(1)
+  return row ?? null
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/heartbeat/
+git commit -m "feat(heartbeat): repository, auth, and health evaluation"
+```
+
+---
+
+## Task 4: Internal Heartbeat API Route
+
+**Files:**
+- Create: `apps/web/app/api/internal/heartbeat/route.ts`
+
+- [ ] **Step 1: Implement route**
+
+```typescript
+// apps/web/app/api/internal/heartbeat/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyCronAuth } from '@/lib/heartbeat/verify-cron-auth'
+import { recordHeartbeat } from '@/lib/heartbeat/repository'
+import { evaluateHealthFromLastSeen } from '@/lib/heartbeat/evaluate-health'
+import { HEARTBEAT_SERVICE_NAME, HEARTBEAT_SOURCE } from '@/lib/heartbeat/constants'
+import { sql } from 'drizzle-orm'
+import { db } from '@/lib/db/connection'
+
+export async function GET(request: NextRequest) {
+  if (!verifyCronAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (process.env.VERCEL_ENV !== 'production') {
+    return NextResponse.json({
+      skipped: true,
+      reason: 'non-production',
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    })
+  }
+
+  const started = Date.now()
+  try {
+    await db.execute(sql`SELECT 1`)
+    const latencyMs = Date.now() - started
+    const now = new Date()
+    const status = evaluateHealthFromLastSeen(now) // fresh beat => pass
+    const environment = process.env.VERCEL_ENV ?? 'production'
+    const deploymentId = process.env.VERCEL_DEPLOYMENT_ID
+
+    await recordHeartbeat({
+      status,
+      latencyMs,
+      environment,
+      deploymentId,
+      source: HEARTBEAT_SOURCE,
+      metadata: { trigger: 'cron' },
+    })
+
+    return NextResponse.json({
+      service: HEARTBEAT_SERVICE_NAME,
+      status,
+      lastSeenAt: now.toISOString(),
+      latencyMs,
+      environment,
+      deploymentId,
+      source: HEARTBEAT_SOURCE,
+    })
+  } catch (error) {
+    console.error('[Heartbeat] failed', error)
+    return NextResponse.json(
+      { error: 'Heartbeat failed', service: HEARTBEAT_SERVICE_NAME },
+      { status: 503 },
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/internal/heartbeat/route.ts
+git commit -m "feat(api): internal cron heartbeat endpoint"
+```
+
+---
+
+## Task 5: Status API Route
+
+**Files:**
+- Create: `apps/web/app/api/status/route.ts`
+
+- [ ] **Step 1: Implement route**
+
+```typescript
+// apps/web/app/api/status/route.ts
+import { NextResponse } from 'next/server'
+import { getLatestHeartbeat } from '@/lib/heartbeat/repository'
+import {
+  evaluateHealthFromLastSeen,
+  ageHoursFromLastSeen,
+} from '@/lib/heartbeat/evaluate-health'
+
+export async function GET() {
+  const checkedAt = new Date().toISOString()
+  const row = await getLatestHeartbeat()
+
+  if (!row) {
+    return NextResponse.json({
+      overall: 'fail',
+      checkedAt,
+      services: [],
+    })
+  }
+
+  const lastSeenAt = new Date(row.lastSeenAt)
+  const status = evaluateHealthFromLastSeen(lastSeenAt)
+
+  return NextResponse.json({
+    overall: status,
+    checkedAt,
+    services: [
+      {
+        serviceName: row.serviceName,
+        status,
+        lastSeenAt: lastSeenAt.toISOString(),
+        ageHours: Math.round(ageHoursFromLastSeen(lastSeenAt) * 10) / 10,
+        latencyMs: row.latencyMs,
+        environment: row.environment,
+        source: row.source,
+      },
+    ],
+  })
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/status/route.ts
+git commit -m "feat(api): public service status endpoint"
+```
+
+---
+
+## Task 6: Middleware, Vercel Cron, Environment
+
+**Files:**
+- Modify: `apps/web/middleware.ts`
+- Modify: `apps/web/vercel.json`
+- Modify: `apps/web/env.config.json`
+
+- [ ] **Step 1: Add public routes in middleware**
+
+In `routeProtection` Map, add:
+
+```typescript
+[/^\/api\/internal\/heartbeat/, ProtectionLevel.PUBLIC],
+[/^\/api\/status/, ProtectionLevel.PUBLIC],
+```
+
+In `isPublicRoute` matcher array, add:
+
+```typescript
+'/api/internal/heartbeat',
+'/api/status',
+```
+
+- [ ] **Step 2: Configure Vercel cron**
+
+In `apps/web/vercel.json`, replace `"crons": []` with:
+
+```json
+"crons": [
+  {
+    "path": "/api/internal/heartbeat",
+    "schedule": "0 5 * * *"
+  }
+]
+```
+
+- [ ] **Step 3: Add `CRON_SECRET` to env config**
+
+In `apps/web/env.config.json` → `optional` array:
+
+```json
+{
+  "name": "CRON_SECRET",
+  "description": "Bearer secret for Vercel Cron invocations of internal heartbeat",
+  "type": "string",
+  "sensitive": true,
+  "validation": { "minLength": 32 }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/middleware.ts apps/web/vercel.json apps/web/env.config.json
+git commit -m "chore: wire cron, public routes, and CRON_SECRET env"
+```
+
+---
+
+## Task 7: Integration Tests (Real Postgres)
+
+**Files:**
+- Create: `apps/web/__tests__/integration/heartbeat-service-health.integration.test.ts`
+
+Follow existing pattern in `real-database-integration.test.ts`: skip when `DATABASE_URL` / Supabase creds unavailable; use unique metadata in rows; clean up events if needed.
+
+- [ ] **Step 1: Write integration test**
+
+```typescript
+import { describe, it, expect, beforeAll } from 'vitest'
+import { recordHeartbeat, getLatestHeartbeat } from '@/lib/heartbeat/repository'
+import { evaluateHealthFromLastSeen } from '@/lib/heartbeat/evaluate-health'
+
+const hasDb =
+  !!process.env.DATABASE_URL ||
+  (!!process.env.NEXT_PUBLIC_SUPABASE_URL && !!process.env.SUPABASE_SERVICE_ROLE_KEY)
+
+describe.skipIf(!hasDb)('heartbeat service health (integration)', () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = 'development' // force real connection if configured
+  })
+
+  it('records heartbeat and reads it back', async () => {
+    const unique = `test-${Date.now()}`
+    await recordHeartbeat({
+      status: 'pass',
+      latencyMs: 1,
+      environment: 'test',
+      source: 'integration-test',
+      metadata: { unique },
+    })
+
+    const row = await getLatestHeartbeat()
+    expect(row).not.toBeNull()
+    expect(row!.status).toBe('pass')
+    expect((row!.metadata as { unique?: string }).unique).toBe(unique)
+  })
+
+  it('evaluates warn and fail thresholds', () => {
+    const now = new Date()
+    const pass = new Date(now.getTime() - 25 * 60 * 60 * 1000)
+    const warn = new Date(now.getTime() - 30 * 60 * 60 * 1000)
+    const fail = new Date(now.getTime() - 50 * 60 * 60 * 1000)
+    expect(evaluateHealthFromLastSeen(pass)).toBe('pass')
+    expect(evaluateHealthFromLastSeen(warn)).toBe('warn')
+    expect(evaluateHealthFromLastSeen(fail)).toBe('fail')
+  })
+})
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+cd /workspace/apps/web && pnpm vitest run __tests__/integration/heartbeat-service-health.integration.test.ts
+```
+
+Expected: PASS when DB configured; SKIP otherwise.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/__tests__/integration/heartbeat-service-health.integration.test.ts
+git commit -m "test: heartbeat integration against real postgres"
+```
+
+---
+
+## Task 8: API Route Tests (Auth & Production Guard)
+
+**Files:**
+- Create: `apps/web/__tests__/api/heartbeat-status.api.test.ts`
+
+- [ ] **Step 1: Test unauthorized heartbeat**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as heartbeatGet } from '../../app/api/internal/heartbeat/route'
+
+describe('/api/internal/heartbeat', () => {
+  beforeEach(() => {
+    vi.stubEnv('CRON_SECRET', 'test-cron-secret-minimum-32-chars!!')
+    vi.stubEnv('VERCEL_ENV', 'production')
+  })
+
+  it('returns 401 without bearer token', async () => {
+    const req = new NextRequest('http://localhost/api/internal/heartbeat')
+    const res = await heartbeatGet(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with wrong bearer token', async () => {
+    const req = new NextRequest('http://localhost/api/internal/heartbeat', {
+      headers: { Authorization: 'Bearer wrong' },
+    })
+    const res = await heartbeatGet(req)
+    expect(res.status).toBe(401)
+  })
+})
+```
+
+- [ ] **Step 2: Test non-production skip**
+
+```typescript
+it('skips writes outside production', async () => {
+  vi.stubEnv('VERCEL_ENV', 'preview')
+  const req = new NextRequest('http://localhost/api/internal/heartbeat', {
+    headers: { Authorization: 'Bearer test-cron-secret-minimum-32-chars!!' },
+  })
+  const res = await heartbeatGet(req)
+  const body = await res.json()
+  expect(res.status).toBe(200)
+  expect(body.skipped).toBe(true)
+})
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /workspace/apps/web && pnpm vitest run __tests__/api/heartbeat-status.api.test.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/__tests__/api/heartbeat-status.api.test.ts
+git commit -m "test: heartbeat route auth and production guard"
+```
+
+---
+
+## Task 9: Production Verification Checklist
+
+Run after deploy to Vercel **production** (documentation update only after these pass).
+
+- [ ] **Step 1: Set `CRON_SECRET` in Vercel Production**
+
+```bash
+vercel env add CRON_SECRET production
+```
+
+- [ ] **Step 2: Apply migrations to production Supabase**
+
+Run Drizzle migrate / Supabase migration against production DB (team process).
+
+- [ ] **Step 3: Manual cron invoke**
+
+```bash
+curl -sS -H "Authorization: Bearer $CRON_SECRET" \
+  "https://<production-domain>/api/internal/heartbeat"
+```
+
+Expected: `200`, `skipped` false, `latencyMs` present.
+
+- [ ] **Step 4: Verify status endpoint**
+
+```bash
+curl -sS "https://<production-domain>/api/status"
+```
+
+Expected: `overall: "pass"`, `services[0].serviceName: "supabase"`.
+
+- [ ] **Step 5: Verify unauthorized blocked**
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}" "https://<production-domain>/api/internal/heartbeat"
+```
+
+Expected: `401`.
+
+- [ ] **Step 6: Confirm row in Supabase**
+
+Query `service_heartbeats` where `service_name = 'supabase'` and recent `service_heartbeat_events` row.
+
+- [ ] **Step 7: Update deployment docs** (only after Steps 1–6 succeed)
+
+Add section to `docs/vercel-deployment.md` covering `CRON_SECRET`, cron schedule, and `/api/status` semantics.
+
+---
+
+## Spec Coverage Self-Review
+
+| Requirement | Task |
+|-------------|------|
+| Vercel Cron scheduled heartbeat | Task 6 (`vercel.json`) |
+| Invokes `/api/internal/heartbeat` | Task 4 |
+| Production-only execution | Task 4, Task 8 |
+| `CRON_SECRET` Bearer validation → 401 | Task 3, 4, 8 |
+| Upsert `service_heartbeats` | Task 1, 3, 4 |
+| Insert `service_heartbeat_events` | Task 1, 3, 4 |
+| Record timestamp, latency, deployment ID, environment | Task 3, 4 |
+| Health pass/warn/fail thresholds | Task 3, 5 |
+| Structured JSON heartbeat response | Task 4 |
+| `GET /api/status` | Task 5 |
+| Cron schedule `0 5 * * *` | Task 6 |
+| Acceptance: unauthorized blocked | Task 8, 9 |
+| Acceptance: Supabase writes queryable | Task 7, 9 |
+
+**Out of scope (future):** event retention/cleanup job, multi-service registry, status UI page, alerting webhooks.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Clerk middleware blocks cron | Public route entries (Task 6) |
+| Preview/staging cron writes test data | `VERCEL_ENV === 'production'` guard |
+| Drizzle vs Supabase migration drift | Update both; run `pnpm db:generate` after schema |
+| Missing `CRON_SECRET` in prod | Fail closed (401); document in Task 9 |
+| `system_metrics` table name confusion | New dedicated tables per spec |
+
+---
+
+## Execution Handoff
+
+**Plan saved to:** `docs/superpowers/plans/2026-05-19-supabase-heartbeat-service-health.md`
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task with review between tasks.
+2. **Inline Execution** — implement tasks sequentially in one session with checkpoints after Tasks 3, 6, and 9.

--- a/supabase/migrations/20260519000000_service_heartbeats.sql
+++ b/supabase/migrations/20260519000000_service_heartbeats.sql
@@ -1,0 +1,27 @@
+-- Service heartbeat tables for platform liveness (server-side writes only)
+CREATE TABLE IF NOT EXISTS service_heartbeats (
+  service_name text PRIMARY KEY,
+  last_seen_at timestamptz NOT NULL,
+  source text NOT NULL,
+  environment text NOT NULL,
+  status text NOT NULL,
+  latency_ms integer,
+  deployment_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS service_heartbeat_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_name text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  status text NOT NULL,
+  latency_ms integer,
+  metadata jsonb DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS service_heartbeat_events_service_occurred_idx
+  ON service_heartbeat_events (service_name, occurred_at DESC);
+
+ALTER TABLE service_heartbeats ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_heartbeat_events ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the mandatory Supabase heartbeat and platform service health capability.

## Changes

- **Schema:** `service_heartbeats` (canonical upsert) + `service_heartbeat_events` (append-only audit)
- **API:** `GET /api/internal/heartbeat` (Vercel Cron, `CRON_SECRET`, production-only writes)
- **API:** `GET /api/status` (public computed health: pass / warn / fail)
- **Config:** Vercel cron `0 5 * * *`, middleware public routes, `CRON_SECRET` in env config
- **Tests:** API auth/production-guard tests; integration tests (real Postgres when `DATABASE_URL` set)

## Post-merge checklist

1. Set `CRON_SECRET` in Vercel Production
2. Run migrations against active Supabase (`pnpm db:migrate` or apply `0001_strong_black_cat.sql`)
3. Verify production cron invoke and `/api/status`

## Plan

See `docs/superpowers/plans/2026-05-19-supabase-heartbeat-service-health.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d878ec35-7fa5-4f21-a9ef-1cc62ccd0e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d878ec35-7fa5-4f21-a9ef-1cc62ccd0e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

